### PR TITLE
Change hover colour on active buttons to meet AA standards

### DIFF
--- a/app/views/design-examples/navigation-global/_styles.scss
+++ b/app/views/design-examples/navigation-global/_styles.scss
@@ -63,7 +63,8 @@
 
     &:hover {
       background: $govuk-blue;
-      text-decoration: underline;      
+      text-decoration: underline;
+      color: $white;
     }
   }
 }


### PR DESCRIPTION
There was a bug where due to specificity the hover colour on a focused active element was black; this caused AA contrast ratings to fail. Pull request introduces white to the hover state on active elements.