### PR TITLE
🔥removing menu link on mobile

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -15,7 +15,6 @@
 
   <div class="header-proposition">
     <div class="content">
-      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
       <nav id="proposition-menu">
         <a href="/" id="proposition-name">
           {# Set serviceName in config.js. Use a block to override on a page. #}


### PR DESCRIPTION
This removes the menu from mobile.

<img width="141" alt="screen shot 2018-08-15 at 09 08 57" src="https://user-images.githubusercontent.com/4334015/44141524-513226f6-a075-11e8-8d54-44a36a617d3f.png">
